### PR TITLE
chore: linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,7 @@ module.exports = {
   plugins: [
   ],
   // add your custom rules here
-  rules: {}
+  rules: {
+    "vue/multi-word-component-names": "off"
+  }
 }

--- a/components/Cta.vue
+++ b/components/Cta.vue
@@ -3,7 +3,24 @@
     <div class="container px-5 py-24 mx-auto">
       <div class="lg:w-2/3 flex flex-col sm:flex-row sm:items-center items-start mx-auto">
         <h1 class="flex-grow sm:pr-16 text-2xl font-medium title-font text-gray-900">{{ blok.text }}</h1>
-        <button class="flex-shrink-0 text-white bg-purple-500 border-0 py-2 px-8 focus:outline-none hover:bg-purple-600 rounded text-lg mt-10 sm:mt-0">{{ blok.button_text }}</button>
+        <button
+          class="
+            flex-shrink-0
+            text-white
+            bg-purple-500
+            border-0
+            py-2
+            px-8
+            focus:outline-none
+            hover:bg-purple-600
+            rounded
+            text-lg
+            mt-10
+            sm:mt-0
+          "
+        >
+          {{ blok.button_text }}
+        </button>
       </div>
     </div>
   </section>
@@ -11,11 +28,11 @@
 
 <script>
 export default {
-props: {
+  props: {
     blok: {
       type: Object,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>

--- a/components/Feature.vue
+++ b/components/Feature.vue
@@ -1,10 +1,6 @@
 <template>
-  <div
-    v-editable="blok"
-    class="py-2 text-center">
-    <img
-      class="mx-auto"
-      :src="blok.icon">
+  <div v-editable="blok" class="py-2 text-center">
+    <img class="mx-auto" :src="blok.icon" />
     <h1 class="text-lg">{{ blok.name }}</h1>
     <p class="text-gray-600">
       {{ blok.description }}
@@ -17,8 +13,8 @@ export default {
   props: {
     blok: {
       type: Object,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -1,12 +1,7 @@
 <template>
-  <ul
-    v-editable="blok"
-    class="flex py-8 mb-6">
-    <li
-      v-for="iblok in blok.columns"
-      :key="iblok._uid"
-      class="flex-auto px-6">
-      <component :is="blok.component" :blok="iblok"/>
+  <ul v-editable="blok" class="flex py-8 mb-6">
+    <li v-for="iblok in blok.columns" :key="iblok._uid" class="flex-auto px-6">
+      <component :is="blok.component" :blok="iblok" />
     </li>
   </ul>
 </template>
@@ -16,8 +11,8 @@ export default {
   props: {
     blok: {
       type: Object,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>

--- a/components/Grid.vue
+++ b/components/Grid.vue
@@ -3,10 +3,10 @@
     v-editable="blok"
     class="flex py-8 mb-6">
     <li
-      :key="blok._uid"
-      v-for="blok in blok.columns"
+      v-for="iblok in blok.columns"
+      :key="iblok._uid"
       class="flex-auto px-6">
-      <component :blok="blok" :is="blok.component" />
+      <component :is="blok.component" :blok="iblok"/>
     </li>
   </ul>
 </template>

--- a/components/Page.vue
+++ b/components/Page.vue
@@ -1,13 +1,6 @@
 <template>
-  <div
-    v-editable="blok"
-    class="px-6">
-    <component
-      :is="blok.component"
-      v-for="iblok in blok.body"
-      :key="iblok._uid"
-      :blok="iblok"
-       />
+  <div v-editable="blok" class="px-6">
+    <component :is="blok.component" v-for="iblok in blok.body" :key="iblok._uid" :blok="iblok" />
   </div>
 </template>
 
@@ -16,8 +9,8 @@ export default {
   props: {
     blok: {
       type: Object,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>

--- a/components/Page.vue
+++ b/components/Page.vue
@@ -3,10 +3,11 @@
     v-editable="blok"
     class="px-6">
     <component
-      v-for="blok in blok.body"
-      :key="blok._uid"
-      :blok="blok"
-      :is="blok.component" />
+      :is="blok.component"
+      v-for="iblok in blok.body"
+      :key="iblok._uid"
+      :blok="iblok"
+       />
   </div>
 </template>
 

--- a/components/Teaser.vue
+++ b/components/Teaser.vue
@@ -1,10 +1,6 @@
 <template>
-  <div
-    v-editable="blok"
-    class="pb-8 mb-6 font-bold text-center">
-    <img
-      class="h-48 w-full mb-4 object-cover"
-      :src="blok.image.filename" />
+  <div v-editable="blok" class="pb-8 mb-6 font-bold text-center">
+    <img class="h-48 w-full mb-4 object-cover" :src="blok.image.filename" />
     <h3 class="text-5xl">{{ blok.headline }}</h3>
   </div>
 </template>
@@ -14,8 +10,8 @@ export default {
   props: {
     blok: {
       type: Object,
-      required: true
-    }
-  }
+      required: true,
+    },
+  },
 }
 </script>


### PR DESCRIPTION
- reorder parameters according to eslint
- disable `multi-word-component-names` rule 
- make inner blok naming explicit
- formatting